### PR TITLE
Containerized version

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,36 @@
+FROM ubuntu:24.04
+
+# Set up non-interactive frontend for apt
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Update and install system-level dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    cmake \
+    libgsl-dev \
+    libyaml-cpp-dev \
+    libfmt-dev \
+    wget \
+    git \
+    software-properties-common && \
+    rm -rf /var/lib/apt/lists/*
+
+# Configure PostgreSQL repository and install PostgreSQL
+RUN sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' && \
+    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
+    apt-get update && apt-get install -y \
+    postgresql-10 \
+    libpq-dev
+
+# Clone, build, and install libpqxx
+RUN git clone https://github.com/jtv/libpqxx.git /tmp/libpqxx && \
+    cd /tmp/libpqxx && \
+    git checkout 7.8.1 && \
+    ./configure --disable-documentation && \
+    make && \
+    make install && \
+    rm -rf /tmp/libpqxx
+
+# Create the build directory
+WORKDIR /project
+RUN mkdir -p build

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,34 +3,32 @@ FROM ubuntu:24.04
 # Set up non-interactive frontend for apt
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Update and install system-level dependencies
+# Update and install system-level dependencies for TMS
 RUN apt-get update && apt-get install -y \
+    autoconf \
+    bison \
     build-essential \
     cmake \
-    libgsl-dev \
-    libyaml-cpp-dev \
-    libfmt-dev \
-    wget \
+    flex \
     git \
-    software-properties-common && \
-    rm -rf /var/lib/apt/lists/*
+    postgresql \
+    software-properties-common
 
-# Configure PostgreSQL repository and install PostgreSQL
-RUN sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' && \
-    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
-    apt-get update && apt-get install -y \
-    postgresql-10 \
-    libpq-dev
+# Install vcpkg dependencies
+RUN apt-get install -y \
+    curl \
+    tar \
+    pkg-config \
+    unzip \
+    zip
+    
+# Install vcpgk
+RUN git clone https://github.com/microsoft/vcpkg.git /usr/local/vcpkg
+# Bootstrap vcpkg
+RUN /usr/local/vcpkg/bootstrap-vcpkg.sh
+# Add vcpkg to PATH
+ENV PATH="/usr/local/vcpkg:${PATH}"
 
-# Clone, build, and install libpqxx
-RUN git clone https://github.com/jtv/libpqxx.git /tmp/libpqxx && \
-    cd /tmp/libpqxx && \
-    git checkout 7.8.1 && \
-    ./configure --disable-documentation && \
-    make && \
-    make install && \
-    rm -rf /tmp/libpqxx
-
-# Create the build directory
-WORKDIR /project
-RUN mkdir -p build
+# Set environment variables for vcpkg integration
+ENV VCPKG_ROOT=/usr/local/vcpkg
+ENV CMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,37 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
 {
-	"name": "Temple-Malaria-Simulation",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	// "image": "mcr.microsoft.com/devcontainers/base:noble",
-
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "uname -a",
-
-	// Configure tool-specific properties.
-	// "customizations": {},
-
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	//"remoteUser": "malsim", // default username is 'ubuntu', build doesn't work without connecting as root
-	/*
-	=======================================================================================================
-	NOTE:
-	Ok so I've tried simply using ubuntu as the remoteUser and others. It seems like I would then need to 
-	modify the Dockerfile to create a user with the same name as the remoteUser. While it is generally inadvisable
-	to run development containers as root (something about malicious code in the container and the root on the 
-	container potentially getting root access on the host), I think it is fine for this project as this is just
-	research code and we shouldn't be accepting pull requests from people we don't know.
-
-	For now, I will just leave remoteUser commented out and connect to the container as root. The working
-	directory will be configured as follows below.
-	=======================================================================================================
-	*/
+	"name": "Spatial-Malaria-Simulation",
 	"workspaceMount": "source=${localWorkspaceFolder},target=/home/${localWorkspaceFolderBasename},type=bind",
 	"workspaceFolder": "/home/${localWorkspaceFolderBasename}",
 	"customizations": {
@@ -55,6 +25,6 @@
 	},
 	"build" : {
 		"dockerfile": "Dockerfile"
-	}//,
-	//"postCreateCommand": "mkdir -p build && cmake -B build   && make -j4"    
+	},
+	"postCreateCommand": "mkdir -p build && cd build && cmake -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake .. && CORES=$(nproc) && make -j$CORES && cd .."
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,44 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+{
+	"name": "Temple-Malaria-Simulation",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	// 	"image": "mcr.microsoft.com/devcontainers/base:noble",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+	"build" : {
+		"dockerfile": "Dockerfile"
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"GitHub.vscode-pull-request-github",
+				"ms-azuretools.vscode-docker",
+				"ms-vscode.makefile-tools",
+				"ms-vscode.cpptools-themes",
+				"ms-vscode.cpptools-extension-pack",
+				"ms-vscode.cpptools",
+				"ms-vscode.cmake-tools",
+				"twxs.cmake",
+				"redhat.vscode-yaml"
+			],
+			"settings": {
+				"terminal.integrated.defaultProfile.linux": "bash"
+			}
+		}
+	}
+	
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,9 +34,6 @@
 	*/
 	"workspaceMount": "source=${localWorkspaceFolder},target=/home/${localWorkspaceFolderBasename},type=bind",
 	"workspaceFolder": "/home/${localWorkspaceFolderBasename}",
-	"build" : {
-		"dockerfile": "Dockerfile"
-	},
 	"customizations": {
 		"vscode": {
 			"extensions": [
@@ -51,9 +48,13 @@
 				"redhat.vscode-yaml"
 			],
 			"settings": {
-				"terminal.integrated.defaultProfile.linux": "bash"
+				"terminal.integrated.defaultProfile.linux": "bash",
+				"cmake.configureOnOpen": true
 			}
 		}
-	}
-	
+	},
+	"build" : {
+		"dockerfile": "Dockerfile"
+	}//,
+	//"postCreateCommand": "mkdir -p build && cmake -B build   && make -j4"    
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Temple-Malaria-Simulation",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	// 	"image": "mcr.microsoft.com/devcontainers/base:noble",
+	// "image": "mcr.microsoft.com/devcontainers/base:noble",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
@@ -18,7 +18,22 @@
 	// "customizations": {},
 
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+	//"remoteUser": "malsim", // default username is 'ubuntu', build doesn't work without connecting as root
+	/*
+	=======================================================================================================
+	NOTE:
+	Ok so I've tried simply using ubuntu as the remoteUser and others. It seems like I would then need to 
+	modify the Dockerfile to create a user with the same name as the remoteUser. While it is generally inadvisable
+	to run development containers as root (something about malicious code in the container and the root on the 
+	container potentially getting root access on the host), I think it is fine for this project as this is just
+	research code and we shouldn't be accepting pull requests from people we don't know.
+
+	For now, I will just leave remoteUser commented out and connect to the container as root. The working
+	directory will be configured as follows below.
+	=======================================================================================================
+	*/
+	"workspaceMount": "source=${localWorkspaceFolder},target=/home/${localWorkspaceFolderBasename},type=bind",
+	"workspaceFolder": "/home/${localWorkspaceFolderBasename}",
 	"build" : {
 		"dockerfile": "Dockerfile"
 	},

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ reporter\.txt
 
 # Ignore log files
 *.log
+
+# Ignore VCPKG dependencies
+vcpkg_installed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+###
+set(CMAKE_TOOLCHAIN_FILE "${CMAKE_TOOLCHAIN_FILE}" CACHE STRING "Vcpkg toolchain file")
+###
+
 option(ENABLE_TRAVEL_TRACKING "Enable tracking of individual travel data and generating travel reports" OFF)
 
 if(ENABLE_TRAVEL_TRACKING)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PSU-CIDD-Malaria-Simulation
+# Temple University - Boni Lab - Spatial Malaria Simulation
 
 [Temple University](https://www.temple.edu/) - [Boni Lab](http://mol.ax/)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A comprehensive [technical manual](manual/manual.pdf) (PDF) for the simulation c
 
 The simulation has been tested to run on Windows 10, Windows Subsystem for Linux (Ubuntu), and Red Hat 7.9. The majority of development is performed on under Linux so building and running under Windows may be impacted.  While basic simulations are possible on desktop computing environments, regional and national scale simulations require advanced computing environments with access to 64 GB of RAM or more. Sample configuration files can be found under [documentation/input/](documentation/input), and examination of `simple.yml` or `spatial.yml` is recommended after working with the demonstration configuration in [documentation/demo/](documentation/demo/).
 
-After cloning the repository to your local computer, the `config.sh` script can be run via `sudo` to install dependencies for building and creation of the build script at `build\build.sh`.
+After cloning the repository to your local computer, the [`config.sh`](https://github.com/rjzupkoii/PSU-CIDD-Malaria-Simulation/blob/4.x.main/config.sh) script can be run via `sudo` to install dependencies for building and creation of the build script at `build\build.sh`.
 
 ## Command Line Arguments
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,22 @@ A comprehensive [technical manual](manual/manual.pdf) (PDF) for the simulation c
 
 The simulation has been tested to run on Windows 10, Windows Subsystem for Linux (Ubuntu), and Red Hat 7.9. The majority of development is performed on under Linux so building and running under Windows may be impacted.  While basic simulations are possible on desktop computing environments, regional and national scale simulations require advanced computing environments with access to 64 GB of RAM or more. Sample configuration files can be found under [documentation/input/](documentation/input), and examination of `simple.yml` or `spatial.yml` is recommended after working with the demonstration configuration in [documentation/demo/](documentation/demo/).
 
-After cloning the repository to your local computer, the [`config.sh`](https://github.com/rjzupkoii/PSU-CIDD-Malaria-Simulation/blob/4.x.main/config.sh) script can be run via `sudo` to install dependencies for building and creation of the build script at `build\build.sh`.
+## Installation
+
+The simulation is semi-portable and is currently run in a Linux environment using a [Development Container](https://containers.dev/) for two reasons. First, there are some system-level dependancies (ex: `cmake` and `flex`) that some users might not use from project to project as compared to a dependency like `git`. Second, the simulation is written in C++ and uses `vcpkg` for package management. `vcpkg` additionally has some system-level dependencies that are not always present on a system and users may not want to install them globally.
+
+The recommended way of building and running the simulation is through Visual Studio Code's [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension. This extension allows for the development of the simulation in a containerized environment that is consistent across all developers. The `Dockerfile` and `devcontainer.json` files are included in the repository for this purpose. This setup requires that [Docker](https://www.docker.com/) be installed on the host machine. The simplest method is to download and install Docker Desktop.
+
+With those prerequisites met, the following steps can be taken to build and run the simulation:
+
+1. Ensure that Docker Desktop is running on the host machine.
+2. Clone the repository to the host machine.
+3. Open the repository in Visual Studio Code.
+4. Open the Command Palette (Ctrl+Shift+P) and select "Dev Containers: Reopen in Container".
+
+After this the Docker will pull the image and build the container and then subsequently the simulation will be built.
+
+If you are not using Visual Studio Code, the Dockerfile can still be used to build the container. To build the simulation once inside the running container, please use the script `scripts/build.sh`.
 
 ## Command Line Arguments
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,16 @@
+{
+    "name": "masim",
+    "dependencies": [
+        "args",
+        "catch",
+        "cli11",
+        "date",
+        "easyloggingpp",
+        "fmt",
+        "gsl",
+        "gtest",
+        "libpqxx",
+        "sqlite3",
+        "yaml-cpp"
+    ]
+}


### PR DESCRIPTION
Switched the installation/build method to a containerized version of `vcpkg`. Everything is built locally inside the container instead of installing package dependencies system wide and having a local install of vcpkg in the repo to manage C++ libraries.